### PR TITLE
Add requirements file and README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# JUB-Scrap
+
+This project scrapes decisions from the Unified Patent Court website and saves them to an Excel file.
+
+## Setup
+
+1. Ensure you have Python installed (version 3.8 or later).
+2. Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the script
+
+Execute `scrap_html.py` to start scraping:
+
+```bash
+python scrap_html.py
+```
+
+The results will be stored in `decisions_html.xlsx` in the project root.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+selenium
+webdriver-manager
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- document setup instructions in README
- list Python package dependencies

## Testing
- `python -m py_compile scrap_html.py`


------
https://chatgpt.com/codex/tasks/task_e_685570d9d22c832fb450b936844811f3