### PR TITLE
Add option to enable JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Once the dependencies are installed, execute the script directly with Python:
 python scrap_html.py
 ```
 
+By default JavaScript is disabled for faster scraping. Use `--enable-js` to
+allow JavaScript, or `--disable-js` to explicitly disable it.
+
 The results will be stored in `decisions_html.xlsx` in the project root.
 =======
 During execution the script will crawl each page until no more data is found. Parsed records are added to `decisions_html.xlsx` and diagnostic messages are stored in **`scrap_html.log`**.


### PR DESCRIPTION
## Summary
- add CLI flags `--enable-js`/`--disable-js`
- pass flag to driver and control JavaScript setting
- document new option in README

## Testing
- `python -m py_compile scrap_html.py`
- `python scrap_html.py --help | head -n 30`

------
https://chatgpt.com/codex/tasks/task_e_6855c5e2c278832fbb7ec5d34cb42912