### PR TITLE
Add PDF download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ python scrap_html.py
 By default JavaScript is disabled for faster scraping. Use `--enable-js` to
 allow JavaScript, or `--disable-js` to explicitly disable it.
 
+Use `--download-pdfs` to automatically fetch linked PDF documents. They will be
+saved in the `decisions` folder with a filename composed of the date, parties,
+registry number and court.
+
 The results will be stored in `decisions_html.xlsx` in the project root.
 =======
 During execution the script will crawl each page until no more data is found. Parsed records are added to `decisions_html.xlsx` and diagnostic messages are stored in **`scrap_html.log`**.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ selenium
 webdriver-manager
 pandas
 openpyxl
+requests


### PR DESCRIPTION
## Summary
- enable PDF downloading to a `decisions` folder with new `--download-pdfs` option
- save PDF filenames built from the date, parties, registry and court
- add helper utilities to sanitize filenames and retry downloads
- document new option and install `requests`

## Testing
- `python -m py_compile scrap_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6855e775e0e0832fb894ae761a778f38