### PR TITLE
Improve PDF download performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ allow JavaScript, or `--disable-js` to explicitly disable it.
 
 Use `--download-pdfs` to automatically fetch linked PDF documents. They will be
 saved in the `decisions` folder with a filename composed of the date, parties,
-registry number and court.
+registry number and court. PDF downloads are performed in parallel using
+multiple threads. Adjust the number of concurrent downloads with
+`--pdf-workers` (default is 4).
 
 The results will be stored in `decisions_html.xlsx` in the project root.
 =======


### PR DESCRIPTION
## Summary
- allow concurrent PDF downloads with `ThreadPoolExecutor`
- add `--pdf-workers` argument and default constant
- document concurrent download option in README

## Testing
- `python3 -m py_compile scrap_html.py`
- `python3 scrap_html.py --help | head -n 40`
- `curl -I https://www.unified-patent-court.org/en/decisions-and-orders 2>&1 | head` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6855e8c2e980832f995dfab199f2f4bb