### PR TITLE
Fix PDF download headers and clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This project scrapes decisions from the Unified Patent Court website and saves t
 
 ```bash
 pip install -r requirements.txt
-=======
+```
+
 This repository contains a small script, `scrap_html.py`, used to collect the public decisions available on the Unified Patent Court website.
 
 ## Purpose of `scrap_html.py`
@@ -42,8 +43,6 @@ pip install -U selenium webdriver-manager pandas openpyxl
 
 ## Running the script
 
-Execute `scrap_html.py` to start scraping:
-=======
 Once the dependencies are installed, execute the script directly with Python:
 
 
@@ -61,7 +60,7 @@ multiple threads. Adjust the number of concurrent downloads with
 `--pdf-workers` (default is 4).
 
 The results will be stored in `decisions_html.xlsx` in the project root.
-=======
+
 During execution the script will crawl each page until no more data is found. Parsed records are added to `decisions_html.xlsx` and diagnostic messages are stored in **`scrap_html.log`**.
 
 

--- a/scrap_html.py
+++ b/scrap_html.py
@@ -23,6 +23,13 @@ LOG_FILE        = "scrap_html.log"
 PDF_DIR         = Path("decisions")
 RETRY_DOWNLOADS = 3
 PDF_WORKERS    = 4  # Threads for parallel PDF downloads
+HEADERS        = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
 
 # Colonnes du DataFrame
 PAGE_COL = "Page"
@@ -199,7 +206,7 @@ def download_pdf(url: str, path: Path, retries: int = RETRY_DOWNLOADS) -> bool:
         return True
     for attempt in range(1, retries + 1):
         try:
-            resp = requests.get(url, timeout=30)
+            resp = requests.get(url, timeout=30, headers=HEADERS)
             if resp.status_code == 200:
                 path.parent.mkdir(parents=True, exist_ok=True)
                 with open(path, "wb") as f:


### PR DESCRIPTION
## Summary
- add a browser-like user agent to PDF download requests
- tidy README by removing merge artifacts

## Testing
- `python -m py_compile scrap_html.py index_pdfs.py`


------
https://chatgpt.com/codex/tasks/task_e_685d3f5183c4832f82eafe01b5b41ce0